### PR TITLE
Allow matching the same regex id multiple times

### DIFF
--- a/src/Laurentvw/Scrapher/Exceptions/MatchIdNotFoundException.php
+++ b/src/Laurentvw/Scrapher/Exceptions/MatchIdNotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Laurentvw\Scrapher\Exceptions;
+
+class MatchIdNotFoundException extends \Exception
+{
+    public function __construct($id)
+    {
+        parent::__construct('The match with ID '.$id.' does not exist in the selector');
+    }
+}

--- a/src/Laurentvw/Scrapher/Selectors/RegexSelector.php
+++ b/src/Laurentvw/Scrapher/Selectors/RegexSelector.php
@@ -2,6 +2,8 @@
 
 namespace Laurentvw\Scrapher\Selectors;
 
+use Laurentvw\Scrapher\Exceptions\MatchIdNotFoundException;
+
 class RegexSelector extends Selector
 {
     public function getMatches()
@@ -12,6 +14,9 @@ class RegexSelector extends Selector
 
         foreach ($matchLines as $i => $matchLine) {
             foreach ($this->getConfig() as $config) {
+                if (!isset($matchLine[$config['id']])) {
+                    throw new MatchIdNotFoundException($config['id']);
+                }
                 $matches[$i][$config['name']] = $matchLine[$config['id']];
             }
         }

--- a/src/Laurentvw/Scrapher/Selectors/RegexSelector.php
+++ b/src/Laurentvw/Scrapher/Selectors/RegexSelector.php
@@ -11,22 +11,12 @@ class RegexSelector extends Selector
         preg_match_all($this->getExpression(), $this->getContent(), $matchLines, PREG_SET_ORDER);
 
         foreach ($matchLines as $i => $matchLine) {
-            foreach ($matchLine as $matchId => $matchValue) {
-                $matches[$i][$this->findName($this->getConfig(), $matchId)] = $matchValue;
+            foreach ($this->getConfig() as $config) {
+                $matches[$i][$config['name']] = $matchLine[$config['id']];
             }
         }
 
         return $matches;
     }
 
-    private function findName($haystack, $needle)
-    {
-        foreach ($haystack as $item) {
-            if ($item['id'] === $needle) {
-                return $item['name'];
-            }
-        }
-
-        return $needle;
-    }
 }


### PR DESCRIPTION
Example:

```
$regex = '/<a.*?href=(?:"(.*?)").*?>(.*?)<\/a>/ms';

$matchConfig = array(
    array(
        'name' => 'url',
        'id' => 1,
    ),
   array(
        'name' => 'domain',
        'id' => 1, // same id as above, works too now!
       'apply' => function($match) { ... }
    ),
    array(
        'name' => 'title',
        'id' => 2, 
    ),
);

$matches = $scrapher->with(new RegexSelector($regex, $matchConfig));
```
